### PR TITLE
Fixing dangling filehandles

### DIFF
--- a/browsercookie/api.py
+++ b/browsercookie/api.py
@@ -55,7 +55,11 @@ def create_local_copy(cookie_file):
     if os.path.exists(cookie_file):
         # copy to random name in tmp folder
         tmp_cookie_file = tempfile.NamedTemporaryFile(suffix='.sqlite').name
-        open(tmp_cookie_file, 'wb').write(open(cookie_file, 'rb').read())
+
+        with open(tmp_cookie_file, 'wb') as tmp_cookie_write_handle:
+            with open(cookie_file, 'rb') as tmp_cookie_read_handle:
+                tmp_cookie_write_handle.write(tmp_cookie_read_handle.read())
+                
         yield tmp_cookie_file
     else:
         raise BrowserCookieError('Can not find cookie file at: ' + cookie_file)


### PR DESCRIPTION
# Description

Hey @akatrevorjay! While I was using this lovely package to do some ad-hoc testing, I noticed the following warning:

```
/Users/briemurphy/virtualenvs/dt-1502/lib/python3.8/site-packages/browsercookie/__init__.py:64: ResourceWarning: unclosed file <_io.BufferedReader name='/Users/briemurphy/Library/Application Support/Google/Chrome/Default/Cookies'>
  tmp_cookie_file_handle.write(open(cookie_file, 'rb').read())
```

This PR changes the cookie handling to the https://www.python.org/dev/peps/pep-0343/ standard. The filehandle will automatically close as soon as it scopes out, and the warning is no longer present.